### PR TITLE
Feature#27 텍스트 감정 처리 api

### DIFF
--- a/src/main/java/com/example/mindfriend/common/response/result/ResultCode.java
+++ b/src/main/java/com/example/mindfriend/common/response/result/ResultCode.java
@@ -20,7 +20,9 @@ public enum ResultCode {
     POST_DIARY_SUCCESS(200, "D001", "일기를 작성하였습니다."),
     GET_DIARY_SUCCESS(200, "D002", "일기 단건 조회하였습니다."),
     GET_DIARYLIST_SUCESS(200, "D003", "일기 리스트를 조회하였습니다"),
-    DELETE_DIARY_SUCCESS(200, "D004", "일기를 삭제하였습니다.");
+    DELETE_DIARY_SUCCESS(200, "D004", "일기를 삭제하였습니다."),
+    GET_MAIN_EMOTION_SUCCEESS(200, "D005", "메인 감정을 조회하였습니다.")
+    ;
     private final int status;
     private final String code;
     private final String message;

--- a/src/main/java/com/example/mindfriend/controller/DiaryController.java
+++ b/src/main/java/com/example/mindfriend/controller/DiaryController.java
@@ -4,8 +4,10 @@ import com.example.mindfriend.common.response.result.ResultCode;
 import com.example.mindfriend.common.response.result.ResultResponse;
 import com.example.mindfriend.domain.Diary;
 import com.example.mindfriend.dto.request.PredictionRequest;
+import com.example.mindfriend.dto.request.postAiDiary;
 import com.example.mindfriend.dto.request.postDiary;
 import com.example.mindfriend.dto.request.postDiaryEmo;
+import com.example.mindfriend.dto.response.GetContentEmo;
 import com.example.mindfriend.dto.response.getDiary;
 import com.example.mindfriend.dto.response.getDiaryDetail;
 import com.example.mindfriend.dto.response.getDiaryList;
@@ -118,5 +120,12 @@ public class DiaryController {
         YearMonth parsedYearMonth = YearMonth.parse(yearMonth);
         List<getDiaryList> response = diaryService.getDiaryForDate(parsedYearMonth);
         return new ResultResponse<>(GET_DIARYLIST_SUCESS, response);
+    }
+
+    // 일기 작성 후 해당 텍스트 감정 반환
+    @PostMapping("/write/emo")
+    public ResultResponse<GetContentEmo> postAiDiary(@RequestPart(value = "postAiDiary") postAiDiary request) {
+        GetContentEmo response = diaryService.postAiDiary(securityUtils.getCurrentUserId(), request);
+        return new ResultResponse<>(POST_DIARY_SUCCESS, response);
     }
 }

--- a/src/main/java/com/example/mindfriend/controller/DiaryController.java
+++ b/src/main/java/com/example/mindfriend/controller/DiaryController.java
@@ -7,10 +7,7 @@ import com.example.mindfriend.dto.request.PredictionRequest;
 import com.example.mindfriend.dto.request.postAiDiary;
 import com.example.mindfriend.dto.request.postDiary;
 import com.example.mindfriend.dto.request.postDiaryEmo;
-import com.example.mindfriend.dto.response.GetContentEmo;
-import com.example.mindfriend.dto.response.getDiary;
-import com.example.mindfriend.dto.response.getDiaryDetail;
-import com.example.mindfriend.dto.response.getDiaryList;
+import com.example.mindfriend.dto.response.*;
 import com.example.mindfriend.security.SecurityUtils;
 import com.example.mindfriend.service.DiaryService;
 import lombok.RequiredArgsConstructor;
@@ -36,7 +33,7 @@ public class DiaryController {
 
     // 일기 작성
     @PostMapping("/write")
-    public ResultResponse<getDiary> postDiary(@RequestPart(value = "postDiary") postDiary request, @RequestPart(value = "postImg")MultipartFile postImg) throws IOException, InterruptedException {
+    public ResultResponse<getDiary> postDiary(@RequestPart(value = "postDiary") postDiary request, @RequestPart(value = "postImg") MultipartFile postImg) throws IOException, InterruptedException {
         getDiary response = diaryService.postDiary(securityUtils.getCurrentUserId(), request, postImg);
         return new ResultResponse<>(ResultCode.POST_DIARY_SUCCESS, response);
     }
@@ -76,7 +73,6 @@ public class DiaryController {
     }
 
 
-
     // 다이어리 단건 조회
     @GetMapping("/read")
     public ResultResponse<getDiaryDetail> getDiaryDetail(@RequestParam String date) {
@@ -86,9 +82,9 @@ public class DiaryController {
 
     // 다이어리 감정 추가
     @PostMapping("/emo")
-    public  ResultResponse<getDiaryDetail> addEmotionToDiary(@RequestBody postDiaryEmo request) {
-        getDiaryDetail response =  diaryService.addEmotionToDiary(request);
-        return  new ResultResponse<>(GET_DIARY_SUCCESS, response);
+    public ResultResponse<getDiaryDetail> addEmotionToDiary(@RequestBody postDiaryEmo request) {
+        getDiaryDetail response = diaryService.addEmotionToDiary(request);
+        return new ResultResponse<>(GET_DIARY_SUCCESS, response);
     }
 
     // 일기 삭제
@@ -127,5 +123,12 @@ public class DiaryController {
     public ResultResponse<GetContentEmo> postAiDiary(@RequestPart(value = "postAiDiary") postAiDiary request) {
         GetContentEmo response = diaryService.postAiDiary(securityUtils.getCurrentUserId(), request);
         return new ResultResponse<>(POST_DIARY_SUCCESS, response);
+    }
+
+    // 다이어리 메인 감정 반환
+    @GetMapping("/main/{diaryIdx}")
+    public ResultResponse<GetMainEmo> getMainEmotion(@PathVariable Long diaryIdx) {
+        GetMainEmo response = diaryService.getMainEmotion(diaryIdx);
+        return new ResultResponse<>(GET_MAIN_EMOTION_SUCCEESS, response);
     }
 }

--- a/src/main/java/com/example/mindfriend/domain/Diary.java
+++ b/src/main/java/com/example/mindfriend/domain/Diary.java
@@ -107,5 +107,4 @@ public class Diary extends BaseEntity {
         }
         return increasedColumn; // 증가한 컬럼 이름 반환
     }
-
 }

--- a/src/main/java/com/example/mindfriend/domain/Diary.java
+++ b/src/main/java/com/example/mindfriend/domain/Diary.java
@@ -40,29 +40,28 @@ public class Diary extends BaseEntity {
     private User user;
 
     @Column(name = "fear")
-    private Long fear;
+    private int fear;
 
     @Column(name = "surprise")
-    private Long surprise;
+    private int surprise;
 
     @Column(name = "angry")
-    private Long angry;
+    private int angry;
 
     @Column(name = "sadness")
-    private Long sadness;
+    private int sadness;
 
     @Column(name = "neutral")
-    private Long neutral;
+    private int neutral;
 
     @Column(name = "happiness")
-    private Long happiness;
+    private int happiness;
 
     @Column(name = "disgust")
-    private Long disgust;
+    private int disgust;
 
     @Column(name = "mainEmotion")
-    private Long mainEmotion;
-
+    private int mainEmotion;
 
     @Builder
     public Diary(User user, String title, String content, String image) {
@@ -71,4 +70,42 @@ public class Diary extends BaseEntity {
         this.content = content;
         this.image = image;
     }
+
+    // == 상태 변경 메서드 == //
+    public String increaseEmo(int emotionType) {
+        String increasedColumn = null; // 증가한 컬럼 이름을 저장할 변수 초기화
+
+        switch (emotionType) {
+            case 1:
+                this.angry++;
+                increasedColumn = "angry"; // angry 증가
+                break;
+            case 2:
+                this.disgust++;
+                increasedColumn = "disgust"; // disgust 증가
+                break;
+            case 3:
+                this.fear++;
+                increasedColumn = "fear"; // fear 증가
+                break;
+            case 4:
+                this.happiness++;
+                increasedColumn = "happiness"; // happiness 증가
+                break;
+            case 5:
+                this.neutral++;
+                increasedColumn = "neutral"; // neutral 증가
+                break;
+            case 6:
+                this.sadness++;
+                increasedColumn = "sadness"; // sadness 증가
+                break;
+            default:
+                this.surprise++;
+                increasedColumn = "surprise"; // surprise 증가
+                break;
+        }
+        return increasedColumn; // 증가한 컬럼 이름 반환
+    }
+
 }

--- a/src/main/java/com/example/mindfriend/domain/Diary.java
+++ b/src/main/java/com/example/mindfriend/domain/Diary.java
@@ -61,7 +61,7 @@ public class Diary extends BaseEntity {
     private int disgust;
 
     @Column(name = "mainEmotion")
-    private int mainEmotion;
+    private String mainEmotion;
 
     @Builder
     public Diary(User user, String title, String content, String image) {

--- a/src/main/java/com/example/mindfriend/dto/request/postAiDiary.java
+++ b/src/main/java/com/example/mindfriend/dto/request/postAiDiary.java
@@ -1,0 +1,8 @@
+package com.example.mindfriend.dto.request;
+
+import lombok.Data;
+
+@Data
+public class postAiDiary {
+    private String content;
+}

--- a/src/main/java/com/example/mindfriend/dto/response/GetContentEmo.java
+++ b/src/main/java/com/example/mindfriend/dto/response/GetContentEmo.java
@@ -1,0 +1,22 @@
+package com.example.mindfriend.dto.response;
+
+import com.example.mindfriend.domain.Diary;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+@Builder
+public class GetContentEmo {
+    private Long diaryIdx;
+    private int emoIdx;
+    private String emotion;
+
+    public static GetContentEmo of(Diary diary, int emoIdx, String emotion) {
+        return GetContentEmo.builder()
+                .diaryIdx(diary.getDiaryIdx())
+                .emoIdx(emoIdx)
+                .emotion(emotion)
+                .build();
+    }
+}

--- a/src/main/java/com/example/mindfriend/dto/response/GetMainEmo.java
+++ b/src/main/java/com/example/mindfriend/dto/response/GetMainEmo.java
@@ -11,11 +11,42 @@ import java.util.Optional;
 @Builder
 public class GetMainEmo {
     private Long diaryIdx;
-    private int mainEmo;
+    private int mainEmoIdx;
+    private String mainEmo;
 
-    public static GetMainEmo of(Optional<Diary> diary, int mainEmo) {
+    public static GetMainEmo of(Optional<Diary> diary) {
+        String mainEmo = diary.map(Diary::getMainEmotion).orElse("");
+        int mainEmoIdx = 0;
+
+        switch (mainEmo) {
+            case "angry":
+                mainEmoIdx = 1;
+                break;
+            case "disgust":
+                mainEmoIdx = 2;
+                break;
+            case "fear":
+                mainEmoIdx = 3;
+                break;
+            case "happiness":
+                mainEmoIdx = 4;
+                break;
+            case "neutral":
+                mainEmoIdx = 5;
+                break;
+            case "sadness":
+                mainEmoIdx = 6;
+                break;
+            case "surprise":
+                mainEmoIdx = 7;
+                break;
+            default:
+                // 기본값 또는 오류 처리를 여기에 추가
+                break;
+        }
         return GetMainEmo.builder()
-                .diaryIdx(diary.get().getDiaryIdx())
+                .diaryIdx(diary.map(Diary::getDiaryIdx).orElse(null))
+                .mainEmoIdx(mainEmoIdx)
                 .mainEmo(mainEmo)
                 .build();
     }

--- a/src/main/java/com/example/mindfriend/dto/response/GetMainEmo.java
+++ b/src/main/java/com/example/mindfriend/dto/response/GetMainEmo.java
@@ -1,0 +1,22 @@
+package com.example.mindfriend.dto.response;
+
+import com.example.mindfriend.domain.Diary;
+import lombok.*;
+
+import java.util.Optional;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+@Builder
+public class GetMainEmo {
+    private Long diaryIdx;
+    private int mainEmo;
+
+    public static GetMainEmo of(Optional<Diary> diary, int mainEmo) {
+        return GetMainEmo.builder()
+                .diaryIdx(diary.get().getDiaryIdx())
+                .mainEmo(mainEmo)
+                .build();
+    }
+}

--- a/src/main/java/com/example/mindfriend/repository/DiaryRepository.java
+++ b/src/main/java/com/example/mindfriend/repository/DiaryRepository.java
@@ -25,20 +25,21 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
     Diary findDiariesCreatedToday(@Param("user") User user, @Param("today") LocalDateTime today);
     @Transactional
     @Modifying(clearAutomatically = true)
-    @Query("UPDATE Diary d SET d.mainEmotion = CASE " +
-            "WHEN d.angry >= d.disgust AND d.angry >= d.fear AND d.angry >= d.happiness " +
-            "AND d.angry >= d.neutral AND d.angry >= d.sadness AND d.angry >= d.surprise THEN d.angry " +
-            "WHEN d.disgust >= d.angry AND d.disgust >= d.fear AND d.disgust >= d.happiness " +
-            "AND d.disgust >= d.neutral AND d.disgust >= d.sadness AND d.disgust >= d.surprise THEN d.disgust " +
-            "WHEN d.fear >= d.angry AND d.fear >= d.disgust AND d.fear >= d.happiness " +
-            "AND d.fear >= d.neutral AND d.fear >= d.sadness AND d.fear >= d.surprise THEN d.fear " +
-            "WHEN d.happiness >= d.angry AND d.happiness >= d.disgust AND d.happiness >= d.fear " +
-            "AND d.happiness >= d.neutral AND d.happiness >= d.sadness AND d.happiness >= d.surprise THEN d.happiness " +
-            "WHEN d.neutral >= d.angry AND d.neutral >= d.disgust AND d.neutral >= d.fear " +
-            "AND d.neutral >= d.happiness AND d.neutral >= d.sadness AND d.neutral >= d.surprise THEN d.neutral " +
-            "WHEN d.sadness >= d.angry AND d.sadness >= d.disgust AND d.sadness >= d.fear " +
-            "AND d.sadness >= d.happiness AND d.sadness >= d.neutral AND d.sadness >= d.surprise THEN d.sadness " +
-            "ELSE d.surprise END " +
+    @Query("UPDATE Diary d SET d.mainEmotion = CASE" +
+            "    WHEN d.angry >= d.disgust AND d.angry >= d.fear AND d.angry >= d.happiness " +
+            "    AND d.angry >= d.neutral AND d.angry >= d.sadness AND d.angry >= d.surprise THEN 'angry' " +
+            "    WHEN d.disgust >= d.angry AND d.disgust >= d.fear AND d.disgust >= d.happiness " +
+            "    AND d.disgust >= d.neutral AND d.disgust >= d.sadness AND d.disgust >= d.surprise THEN 'disgust' " +
+            "    WHEN d.fear >= d.angry AND d.fear >= d.disgust AND d.fear >= d.happiness " +
+            "    AND d.fear >= d.neutral AND d.fear >= d.sadness AND d.fear >= d.surprise THEN 'fear' " +
+            "    WHEN d.happiness >= d.angry AND d.happiness >= d.disgust AND d.happiness >= d.fear " +
+            "    AND d.happiness >= d.neutral AND d.happiness >= d.sadness AND d.happiness >= d.surprise THEN 'happiness' " +
+            "    WHEN d.neutral >= d.angry AND d.neutral >= d.disgust AND d.neutral >= d.fear " +
+            "    AND d.neutral >= d.happiness AND d.neutral >= d.sadness AND d.neutral >= d.surprise THEN 'neutral' " +
+            "    WHEN d.sadness >= d.angry AND d.sadness >= d.disgust AND d.sadness >= d.fear " +
+            "    AND d.sadness >= d.happiness AND d.sadness >= d.neutral AND d.sadness >= d.surprise THEN 'sadness' " +
+            "    ELSE 'surprise' " +
+            "END " +
             "WHERE d.diaryIdx = :diaryIdx")
     void updateMainEmotion(@Param("diaryIdx") Long diaryIdx);
 }

--- a/src/main/java/com/example/mindfriend/repository/DiaryRepository.java
+++ b/src/main/java/com/example/mindfriend/repository/DiaryRepository.java
@@ -3,6 +3,8 @@ package com.example.mindfriend.repository;
 import com.example.mindfriend.domain.Diary;
 import com.example.mindfriend.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -13,6 +15,10 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
 
     List<Diary> findByCreatedAtBetweenAndMainEmotion(LocalDateTime startDateTime, LocalDateTime endDateTime, Long emotion);
 
-    List<Diary> findByCreatedAtBetweenAndContentContaining(LocalDateTime startDateTime, LocalDateTime endDateTime,String keyword);
+    List<Diary> findByCreatedAtBetweenAndContentContaining(LocalDateTime startDateTime, LocalDateTime endDateTime, String keyword);
+
     List<Diary> findByCreatedAtBetween(LocalDateTime startDateTime, LocalDateTime endDateTime);
+    @Query("SELECT d FROM Diary d WHERE d.user = :user AND FUNCTION('DATE', d.createdAt) = FUNCTION('DATE', :today)")
+    Diary findDiariesCreatedToday(@Param("user") User user, @Param("today") LocalDateTime today);
+
 }

--- a/src/main/java/com/example/mindfriend/repository/DiaryRepository.java
+++ b/src/main/java/com/example/mindfriend/repository/DiaryRepository.java
@@ -21,4 +21,6 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
     @Query("SELECT d FROM Diary d WHERE d.user = :user AND FUNCTION('DATE', d.createdAt) = FUNCTION('DATE', :today)")
     Diary findDiariesCreatedToday(@Param("user") User user, @Param("today") LocalDateTime today);
 
+    Diary findByMainEmotion(Long diaryIdx);
+
 }

--- a/src/main/java/com/example/mindfriend/repository/DiaryRepository.java
+++ b/src/main/java/com/example/mindfriend/repository/DiaryRepository.java
@@ -3,8 +3,11 @@ package com.example.mindfriend.repository;
 import com.example.mindfriend.domain.Diary;
 import com.example.mindfriend.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
+
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -20,7 +23,22 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
     List<Diary> findByCreatedAtBetween(LocalDateTime startDateTime, LocalDateTime endDateTime);
     @Query("SELECT d FROM Diary d WHERE d.user = :user AND FUNCTION('DATE', d.createdAt) = FUNCTION('DATE', :today)")
     Diary findDiariesCreatedToday(@Param("user") User user, @Param("today") LocalDateTime today);
-
-    Diary findByMainEmotion(Long diaryIdx);
-
+    @Transactional
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE Diary d SET d.mainEmotion = CASE " +
+            "WHEN d.angry >= d.disgust AND d.angry >= d.fear AND d.angry >= d.happiness " +
+            "AND d.angry >= d.neutral AND d.angry >= d.sadness AND d.angry >= d.surprise THEN d.angry " +
+            "WHEN d.disgust >= d.angry AND d.disgust >= d.fear AND d.disgust >= d.happiness " +
+            "AND d.disgust >= d.neutral AND d.disgust >= d.sadness AND d.disgust >= d.surprise THEN d.disgust " +
+            "WHEN d.fear >= d.angry AND d.fear >= d.disgust AND d.fear >= d.happiness " +
+            "AND d.fear >= d.neutral AND d.fear >= d.sadness AND d.fear >= d.surprise THEN d.fear " +
+            "WHEN d.happiness >= d.angry AND d.happiness >= d.disgust AND d.happiness >= d.fear " +
+            "AND d.happiness >= d.neutral AND d.happiness >= d.sadness AND d.happiness >= d.surprise THEN d.happiness " +
+            "WHEN d.neutral >= d.angry AND d.neutral >= d.disgust AND d.neutral >= d.fear " +
+            "AND d.neutral >= d.happiness AND d.neutral >= d.sadness AND d.neutral >= d.surprise THEN d.neutral " +
+            "WHEN d.sadness >= d.angry AND d.sadness >= d.disgust AND d.sadness >= d.fear " +
+            "AND d.sadness >= d.happiness AND d.sadness >= d.neutral AND d.sadness >= d.surprise THEN d.sadness " +
+            "ELSE d.surprise END " +
+            "WHERE d.diaryIdx = :diaryIdx")
+    void updateMainEmotion(@Param("diaryIdx") Long diaryIdx);
 }

--- a/src/main/java/com/example/mindfriend/service/DiaryService.java
+++ b/src/main/java/com/example/mindfriend/service/DiaryService.java
@@ -226,10 +226,8 @@ public class DiaryService {
     }
 
     public GetMainEmo getMainEmotion(Long diaryIdx) {
-
         Optional<Diary> diary = diaryRepository.findById(diaryIdx);
 
-        int mainEmo = diary.get().getMainEmotion();
-        return GetMainEmo.of(diary, mainEmo);
+        return GetMainEmo.of(diary);
     }
 }

--- a/src/main/java/com/example/mindfriend/service/DiaryService.java
+++ b/src/main/java/com/example/mindfriend/service/DiaryService.java
@@ -69,7 +69,7 @@ public class DiaryService {
             try (InputStream inputStream = process.getInputStream();
                  BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream))) {
                 String line;
-                while((line = reader.readLine()) != null) {
+                while ((line = reader.readLine()) != null) {
                     output.append(line).append("\n");
                 }
             }
@@ -81,15 +81,27 @@ public class DiaryService {
             e.printStackTrace();
         }
 
-        Diary diary = request.toEntity(userPostImg);
-        diary.setUser(user);
+        // 오늘 날짜 일기 찾기
+        LocalDateTime today = LocalDateTime.now();
 
-        Diary response = diaryRepository.save(diary);
-        if (response == null) {
-            throw new MindFriendBusinessException(POST_DIARY_FAIL);
+        Diary existingDiary = diaryRepository.findDiariesCreatedToday(user, today);
+
+        if (existingDiary != null) {
+
+            // 이미 오늘 일기가 존재한다면 내용을 추가
+            existingDiary.setTitle(request.getTitle());
+            existingDiary.setContent(request.getContent());
+            existingDiary.setImage(userPostImg);
+
+            Diary response = diaryRepository.save(existingDiary);
+            if (response == null) {
+                throw new MindFriendBusinessException(POST_DIARY_FAIL);
+            }
+            return getDiary.of(response);
         }
-        return getDiary.of(response);
+        throw new MindFriendBusinessException(POST_DIARY_FAIL);
     }
+
 
     private String runModelWithContent(String content) {
         // content 값을 가지고 모델 실행을 수행하고 결과를 반환하는 코드 작성
@@ -193,7 +205,6 @@ public class DiaryService {
         Random random = new Random();
 
         int randomInt = random.nextInt(7);
-        System.out.println(randomInt);
 
         Diary diary = new Diary();
         diary.setUser(user);

--- a/src/main/java/com/example/mindfriend/service/DiaryService.java
+++ b/src/main/java/com/example/mindfriend/service/DiaryService.java
@@ -4,8 +4,10 @@ import com.example.mindfriend.common.response.exception.MindFriendBusinessExcept
 import com.example.mindfriend.common.response.exception.UserNotFoundException;
 import com.example.mindfriend.domain.Diary;
 import com.example.mindfriend.domain.User;
+import com.example.mindfriend.dto.request.postAiDiary;
 import com.example.mindfriend.dto.request.postDiary;
 import com.example.mindfriend.dto.request.postDiaryEmo;
+import com.example.mindfriend.dto.response.GetContentEmo;
 import com.example.mindfriend.dto.response.getDiary;
 import com.example.mindfriend.dto.response.getDiaryDetail;
 import com.example.mindfriend.dto.response.getDiaryList;
@@ -31,6 +33,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.Random;
 
 import static com.example.mindfriend.common.response.exception.ErrorCode.*;
 
@@ -118,11 +121,6 @@ public class DiaryService {
         return getDiaryDetail.of(diary);
     }
 
-
-
-
-
-
     // 일기 감정 수정(추가)
     public getDiaryDetail addEmotionToDiary(postDiaryEmo request) {
         Diary diary = diaryRepository.findById(request.getDiaryIdx())
@@ -180,5 +178,29 @@ public class DiaryService {
         List<Diary> diaries = diaryRepository.findByCreatedAtBetween(startDateTime, endDateTime);
 
         return getDiaryList.of(diaries);
+    }
+
+    public GetContentEmo postAiDiary(String userIdx, postAiDiary request) {
+        User user = userRepository.findByUserId(userIdx)
+                .orElseThrow(UserNotFoundException::new);
+
+        /*
+        ai 텍스트 분석이 처리가 완료되면
+        해당 텍스트에 대한 감정 인덱스 반환 코드 추가 예정
+        현재는 분석이 완료되었다는 가정하에 랜덤값 반환됨
+         */
+
+        Random random = new Random();
+
+        int randomInt = random.nextInt(7);
+        System.out.println(randomInt);
+
+        Diary diary = new Diary();
+        diary.setUser(user);
+        String increasedEmotion = diary.increaseEmo(randomInt);
+
+        Diary response = diaryRepository.save(diary);
+
+        return GetContentEmo.of(response, randomInt, increasedEmotion);
     }
 }

--- a/src/main/java/com/example/mindfriend/service/DiaryService.java
+++ b/src/main/java/com/example/mindfriend/service/DiaryService.java
@@ -203,13 +203,25 @@ public class DiaryService {
 
         int randomInt = random.nextInt(7);
 
-        Diary diary = new Diary();
-        diary.setUser(user);
-        String increasedEmotion = diary.increaseEmo(randomInt);
+        LocalDateTime today = LocalDateTime.now();
+        Diary existingDiary = diaryRepository.findDiariesCreatedToday(user, today);
 
-        Diary response = diaryRepository.save(diary);
+        // 기존에 작성한 일기가 없다면
+        if (existingDiary == null) {
+            Diary diary = new Diary();
+            diary.setUser(user);
+            String increasedEmotion = diary.increaseEmo(randomInt);
 
-        return GetContentEmo.of(response, randomInt, increasedEmotion);
+            Diary response = diaryRepository.save(diary);
+
+            return GetContentEmo.of(response, randomInt, increasedEmotion);
+        } else {
+
+            String increasedEmotion = existingDiary.increaseEmo(randomInt);
+            Diary updatedDiary = diaryRepository.save(existingDiary);
+
+            return GetContentEmo.of(updatedDiary, randomInt, increasedEmotion);
+        }
     }
 
     public GetMainEmo getMainEmotion(Long diaryIdx) {
@@ -218,6 +230,5 @@ public class DiaryService {
 
         int mainEmo = diary.get().getMainEmotion();
         return GetMainEmo.of(diary, mainEmo);
-
     }
 }

--- a/src/main/java/com/example/mindfriend/service/DiaryService.java
+++ b/src/main/java/com/example/mindfriend/service/DiaryService.java
@@ -7,10 +7,7 @@ import com.example.mindfriend.domain.User;
 import com.example.mindfriend.dto.request.postAiDiary;
 import com.example.mindfriend.dto.request.postDiary;
 import com.example.mindfriend.dto.request.postDiaryEmo;
-import com.example.mindfriend.dto.response.GetContentEmo;
-import com.example.mindfriend.dto.response.getDiary;
-import com.example.mindfriend.dto.response.getDiaryDetail;
-import com.example.mindfriend.dto.response.getDiaryList;
+import com.example.mindfriend.dto.response.*;
 import com.example.mindfriend.repository.DiaryRepository;
 import com.example.mindfriend.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -213,5 +210,14 @@ public class DiaryService {
         Diary response = diaryRepository.save(diary);
 
         return GetContentEmo.of(response, randomInt, increasedEmotion);
+    }
+
+    public GetMainEmo getMainEmotion(Long diaryIdx) {
+
+        Optional<Diary> diary = diaryRepository.findById(diaryIdx);
+
+        int mainEmo = diary.get().getMainEmotion();
+        return GetMainEmo.of(diary, mainEmo);
+
     }
 }

--- a/src/main/java/com/example/mindfriend/service/DiaryService.java
+++ b/src/main/java/com/example/mindfriend/service/DiaryService.java
@@ -216,9 +216,10 @@ public class DiaryService {
 
             return GetContentEmo.of(response, randomInt, increasedEmotion);
         } else {
-
             String increasedEmotion = existingDiary.increaseEmo(randomInt);
             Diary updatedDiary = diaryRepository.save(existingDiary);
+
+            diaryRepository.updateMainEmotion(updatedDiary.getDiaryIdx());
 
             return GetContentEmo.of(updatedDiary, randomInt, increasedEmotion);
         }


### PR DESCRIPTION
- 단일 문장으로 입력 시 데이터베이스 상 요청 값은 저장되지 않고 감정만 카운트하도록 구현
- 일기 작성 완료 버튼 클릭 시 일기 전체가 저장되며 7개의 감정 중 카운트가 가장 높은 감정을 메인 감정이름으로 저장
- 일기인덱스를 PathVariable로 받아 메인 감정 조회 시 메인 감정인덱스, 감정 이름 반환
---
현재 ai 와 api 서버 통신 미구현 상태라 감정은 랜덤값으로 생성 
응답 구조만 파악 후 안드 쪽 서버통신 구현 하면 될듯
포스트맨 명세서 업데이트 완료 